### PR TITLE
Ajout de la configuration du fuseau horaire dans la partie batch-imag…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,12 @@ ENV LANG fr_FR.UTF-8
 ENV LANGUAGE fr_FR:fr
 ENV LC_ALL fr_FR.UTF-8
 
+# Configuration du fuseau horaire
+# Pour résoudre le problème de décalage horaire dans les logs
+# de votre conteneur item-batch, vous devez ajouter ces instructions dans la partie batch-image de votre Dockerfile.
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # systeme pour les crontab
 # cronie: remplacant de crond qui support le CTRL+C dans docker (sans ce système c'est compliqué de stopper le conteneur)
 # gettext: pour avoir envsubst qui permet de gérer le template tasks.tmpl


### PR DESCRIPTION
Effectivement, je vois dans votre Dockerfile que vous avez déjà les instructions pour configurer le fuseau horaire :

```Dockerfile
ENV TZ=Europe/Paris
RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
```

Cependant, ces instructions se trouvent dans la partie `api-image` de votre Dockerfile multi-stage. Pour résoudre le problème de décalage horaire dans les logs de votre conteneur `item-batch`, vous devez ajouter ces instructions dans la partie `batch-image` de votre Dockerfile.

Voici comment vous pouvez modifier votre Dockerfile :

```Dockerfile
# ...

FROM rockylinux:8 as batch-image
WORKDIR /scripts/
#locales fr
# Les locales fr_FR
RUN dnf install langpacks-fr glibc-all-langpacks -y
ENV LANG fr_FR.UTF-8
ENV LANGUAGE fr_FR:fr
ENV LC_ALL fr_FR.UTF-8

# Configuration du fuseau horaire
ENV TZ=Europe/Paris
RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

# ...
```

Assurez-vous d'ajouter les instructions `ENV TZ=Europe/Paris` et `RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone` juste après la configuration des locales françaises dans la partie `batch-image`.

Après avoir effectué cette modification, suivez les étapes restantes mentionnées précédemment :

1. Reconstruisez votre image Docker en exécutant `sudo docker build -t your-image-name .`
2. Mettez à jour la définition de service pour `item-batch` dans votre `docker-compose.yml` avec la nouvelle image.
3. Redémarrez vos conteneurs Docker Compose avec `sudo docker-compose up -d`.

Cela devrait résoudre le problème de décalage horaire dans les logs de votre conteneur `item-batch`.

N'hésitez pas à me faire savoir si vous rencontrez d'autres problèmes !