### PR TITLE
- Ajout d'un filtre sur 930$b afin de n'afficher que les exemplaires …

### DIFF
--- a/core/src/main/java/fr/abes/item/core/service/impl/DemandeSuppService.java
+++ b/core/src/main/java/fr/abes/item/core/service/impl/DemandeSuppService.java
@@ -361,6 +361,8 @@ public class DemandeSuppService extends DemandeService implements IDemandeServic
         try {
             traitementService.authenticate("M" + demandeSupp.getRcr());
             List<Exemplaire> exemplairesExistants = getExemplairesExistants(ligneFichierSupp);
+            //On ne conserve que les EPN de son RCR
+            exemplairesExistants = exemplairesExistants.stream().filter(exemplaire -> exemplaire.findZone("930", 0).findSubLabel("$b").equals(demandeSupp.getRcr())).toList();
             if (exemplairesExistants.isEmpty()) {
                 return new String[] {
                         ligneFichierSupp.getPpn(),


### PR DESCRIPTION
…de son RCR et non plus les exemplaires de son ILN

- Les exemplaires restants sont calculés à partir des exemplaires filtrés, normalement il n'y a pas lieu de procéder à un second filtre