### PR TITLE
Conservation de l'ordre des ppns dans le fichier initial tout au long du workflow

### DIFF
--- a/core/src/main/java/fr/abes/item/core/service/impl/DemandeSuppService.java
+++ b/core/src/main/java/fr/abes/item/core/service/impl/DemandeSuppService.java
@@ -194,7 +194,7 @@ public class DemandeSuppService extends DemandeService implements IDemandeServic
             fichierPrepare.ecrireEnTete();
             //Alimentation du fichier par appel à la procédure Oracle ppntoepn
             appelProcStockee(demande.getRcr(), demande.getTypeSuppression());
-            fichierPrepare.trierLignesDeCorrespondances();
+            //fichierPrepare.trierLignesDeCorrespondances();
             demande.setEtatDemande(new EtatDemande(Constant.ETATDEM_PREPAREE));
             save(demande);
             checkEtatDemandeAndStoreLignesInDatabase(demande);


### PR DESCRIPTION
Les ppns envoyés ou retrouvés dans le cadre des calculs de fichier de correspondances correspondat à l'ordre des ppn dans le fichier initial d'envoi (suppression du tri)