### PR TITLE
- changement regex pattern

### DIFF
--- a/core/src/main/java/fr/abes/item/core/service/impl/LigneFichierSuppService.java
+++ b/core/src/main/java/fr/abes/item/core/service/impl/LigneFichierSuppService.java
@@ -62,7 +62,7 @@ public class LigneFichierSuppService implements ILigneFichierService {
             List<LigneFichierSupp> listToSave = new ArrayList<>();
 
             // Pattern fonctionnel avec gestion des espaces
-            String lignePattern = "\\s*(?<ppn>\\d{1,9}X?)\\s*;\\s*(?<rcr>\\d{8,9})\\s*;\\s*(?<epn>\\d{1,9}X?)\\s*";
+            String lignePattern = "\\s*(?<ppn>\\d{1,9}X?)?\\s*;\\s*(?<rcr>\\d{8,9})\\s*;\\s*(?<epn>\\d{1,9}X?)\\s*";
             Pattern regexp = Pattern.compile(lignePattern);
 
             while ((line = reader.readLine()) != null) {
@@ -100,6 +100,7 @@ public class LigneFichierSuppService implements ILigneFichierService {
                     }
                 }
 
+                log.error(ppn, rcr, epn);
                 LigneFichierSupp lf = new LigneFichierSupp(ppn, rcr, epn, position++, 0, "", demandeSupp);
                 listToSave.add(lf);
             }

--- a/core/src/main/java/fr/abes/item/core/service/impl/LigneFichierSuppService.java
+++ b/core/src/main/java/fr/abes/item/core/service/impl/LigneFichierSuppService.java
@@ -100,7 +100,6 @@ public class LigneFichierSuppService implements ILigneFichierService {
                     }
                 }
 
-                log.error(ppn, rcr, epn);
                 LigneFichierSupp lf = new LigneFichierSupp(ppn, rcr, epn, position++, 0, "", demandeSupp);
                 listToSave.add(lf);
             }


### PR DESCRIPTION
- forme ppn_vide;rcr;epn reconnue
- précédement seul forme ppn;rcr;epn reconnue
- permet obtention fichiers resultats avec epn renseigné, pour service suppression par chargement fichier epn.