### PR TITLE
SOA-518: fiabiliser le guard cron batch et corriger le warning Log4j2 dark

### DIFF
--- a/batch/src/main/resources/log4j2.xml
+++ b/batch/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
         <!-- CONSOLE -->
         <Console name="Console">
             <PatternLayout
-                    pattern="%style{%d{ISO8601}}{white} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%C{1.}}{dark,yellow}: %msg%n%throwable" />
+                    pattern="%style{%d{ISO8601}}{white} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%C{1.}}{yellow}: %msg%n%throwable" />
         </Console>
         <ItemLogAppender name="ItemLogAppender" />
     </Appenders>

--- a/docker/batch/itemBatchDemandesPlusDeTroisMois.sh
+++ b/docker/batch/itemBatchDemandesPlusDeTroisMois.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 
 LANG=fr_FR.UTF-8
 
-# Evite un chevauchement si une execution precedente est encore en cours.
-if [[ $(pgrep -cf "itemBatchDemandesPlusDeTroisMois.sh") -gt 1 ]]; then
+# Evite un chevauchement (fiable avec cron, sans faux positif sur le shell wrapper).
+LOCK_FILE="/tmp/itemBatchDemandesPlusDeTroisMois.lock"
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
   echo "Une execution de itemBatchDemandesPlusDeTroisMois est deja en cours, sortie."
   exit 0
 fi

--- a/web/src/main/resources/log4j2.xml
+++ b/web/src/main/resources/log4j2.xml
@@ -5,7 +5,7 @@
         <!-- CONSOLE -->
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout
-                    pattern="%style{%d{ISO8601}}{white} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%C{1.}}{dark,yellow}: %msg%n%throwable" />
+                    pattern="%style{%d{ISO8601}}{white} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%C{1.}}{yellow}: %msg%n%throwable" />
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
Description

  1. Contexte

  - Cette PR corrige 2 points mineurs détectés après déploiement develop.
  - Objectif: éviter un faux positif de chevauchement cron côté batch et supprimer un warning de démarrage Log4j2 côté API/Batch.

  2. Correctif 1: guard anti-chevauchement cron du batch

  - Fichier modifié: docker/batch/itemBatchDemandesPlusDeTroisMois.sh
  - Remplacement du contrôle basé sur pgrep -cf par un verrou flock (/tmp/itemBatchDemandesPlusDeTroisMois.lock).
  - Pourquoi:
      - pgrep -f peut matcher le wrapper shell cron (/bin/sh -c ...) et compter 2 processus dès un lancement normal.
      - Risque: sortie immédiate du script sans exécuter les jobs.
  - Résultat:
      - Une seule exécution autorisée à la fois, sans faux positif lié à cron.

  3. Correctif 2: warning Log4j2 style attribute dark is incorrect

  - Fichiers modifiés:
      - web/src/main/resources/log4j2.xml
      - batch/src/main/resources/log4j2.xml
  - Changement:
      - %style{%C{1.}}{dark,yellow} -> %style{%C{1.}}{yellow}
  - Pourquoi:
      - dark n’est pas une valeur valide pour AnsiEscape dans Log4j2.
  - Résultat:
      - Suppression du warning au bootstrap des conteneurs.

  4. Validation

  - Build/tests exécutés sous JDK 21:
      - mvn -s specs/maven-settings-baseline.xml clean test
      - Résultat: BUILD SUCCESS (core 90, web 23, batch 0).

  5. Commits

  - d8178e3 SOA-518: make >3 months batch overlap guard cron-safe
  - 578c22c SOA-518: remove invalid Log4j2 dark style in console patterns