### PR TITLE
SOA-801 - Ajouter la publication Docker WUD pour item-api et item-batch

### DIFF
--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -27,12 +27,22 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: "Prepare API Docker tags"
-        id: docker_tag_meta
+        id: api_docker_tag_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
           flavor: |
             latest=auto
+            suffix=-api
+
+      - name: "Prepare Batch Docker tags"
+        id: batch_docker_tag_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
+          flavor: |
+            latest=auto
+            suffix=-batch
 
       - name: "Login to DockerHub"
         uses: docker/login-action@v3
@@ -46,7 +56,7 @@ jobs:
         with:
           push: true
           target: api-image
-          tags: ${{ steps.docker_tag_meta.outputs.tags }}-api
+          tags: ${{ steps.api_docker_tag_meta.outputs.tags }}
 
       - name: "Buildx and push Batch"
         id: push-batch
@@ -54,4 +64,4 @@ jobs:
         with:
           push: true
           target: batch-image
-          tags: ${{ steps.docker_tag_meta.outputs.tags }}-batch
+          tags: ${{ steps.batch_docker_tag_meta.outputs.tags }}

--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -27,22 +27,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: "Prepare API Docker tags"
-        id: api_docker_tag_meta
+        id: docker_tag_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
           flavor: |
             latest=auto
-            suffix=-api
-
-      - name: "Prepare Batch Docker tags"
-        id: batch_docker_tag_meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
-          flavor: |
-            latest=auto
-            suffix=-batch
 
       - name: "Login to DockerHub"
         uses: docker/login-action@v3
@@ -51,15 +41,17 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Buildx and push API"
+        id: push-api
         uses: docker/build-push-action@v6
         with:
           push: true
           target: api-image
-          tags: ${{ steps.api_docker_tag_meta.outputs.tags }}
+          tags: ${{ steps.docker_tag_meta.outputs.tags }}-api
 
       - name: "Buildx and push Batch"
+        id: push-batch
         uses: docker/build-push-action@v6
         with:
           push: true
           target: batch-image
-          tags: ${{ steps.batch_docker_tag_meta.outputs.tags }}
+          tags: ${{ steps.docker_tag_meta.outputs.tags }}-batch

--- a/.github/workflows/wud-build-pubtodockerhub.yml
+++ b/.github/workflows/wud-build-pubtodockerhub.yml
@@ -1,0 +1,65 @@
+name: wud-build-pubtodockerhub.yml
+
+env:
+  DOCKERHUB_IMAGE_PREFIX: abesesr/item
+
+on:
+  workflow_dispatch:
+
+  repository_dispatch:
+    types:
+      - wud
+
+jobs:
+  build-pubtodockerhub:
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v6
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Prepare API Docker tags"
+        id: api_docker_tag_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
+          flavor: |
+            latest=auto
+            suffix=-api
+
+      - name: "Prepare Batch Docker tags"
+        id: batch_docker_tag_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_IMAGE_PREFIX }}
+          flavor: |
+            latest=auto
+            suffix=-batch
+
+      - name: "Login to DockerHub"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Buildx and push API"
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          target: api-image
+          tags: ${{ steps.api_docker_tag_meta.outputs.tags }}
+
+      - name: "Buildx and push Batch"
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          target: batch-image
+          tags: ${{ steps.batch_docker_tag_meta.outputs.tags }}


### PR DESCRIPTION
## Contexte

Ajout du workflow nécessaire à la migration WUD pour les images Docker `item-api` et `item-batch`.

## Changements

- Ajout de la GitHub Action `.github/workflows/wud-build-pubtodockerhub.yml`.
- Publication des images DockerHub `abesesr/item` pour les targets `api-image` et `batch-image`.
- Génération des tags avec suffixes via `docker/metadata-action` :
  - `develop-api` / `develop-batch`
  - `main-api` / `main-batch`
  - tags de release suffixés `-api` / `-batch`
- Déclenchement possible via `workflow_dispatch` et `repository_dispatch: wud`.

## Validation

- Action GitHub exécutée avec succès sur `develop`.
- Images `abesesr/item:develop-api` et `abesesr/item:develop-batch` publiées.
- WUD validé sur `diplotaxis5-dev` : détection du nouveau digest et redéploiement de `item-api`; `item-batch` vu à jour par WUD.