### PR TITLE
[SOA-689] Message explicite si l'EPN est absent de la notice

### DIFF
--- a/batch/src/main/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessor.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessor.java
@@ -179,11 +179,13 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
                 }
                 if (ligneFichierDtoSupp.getEpn() != null) {
                     Optional<Exemplaire> exemplaireASupprimerOpt = exemplaireWithType.getExemplaires().stream().filter(exemplaire -> exemplaire.findZone("A99", 0).getValeur().equals(ligneFichierDtoSupp.getEpn())).findFirst();
-                    if (exemplaireASupprimerOpt.isPresent()) {
-                        //Type de document non présent dans le fichier de sauvegarde txt, seulement dans le csv
-                        this.fichierSauvegardeSuppTxt.writePpnInFile(ligneFichierDtoSupp.getPpn(), exemplaireASupprimerOpt.get());
-                        this.fichierSauvegardeSuppcsv.writePpnInFile(ligneFichierDtoSupp.getPpn(), exemplaireASupprimerOpt.get(), exemplaireWithType.getType());
+                    if (exemplaireASupprimerOpt.isEmpty()) {
+                        ligneFichierDtoSupp.setRetourSudoc(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE);
+                        return ligneFichierDtoSupp;
                     }
+                    //Type de document non présent dans le fichier de sauvegarde txt, seulement dans le csv
+                    this.fichierSauvegardeSuppTxt.writePpnInFile(ligneFichierDtoSupp.getPpn(), exemplaireASupprimerOpt.get());
+                    this.fichierSauvegardeSuppcsv.writePpnInFile(ligneFichierDtoSupp.getPpn(), exemplaireASupprimerOpt.get(), exemplaireWithType.getType());
                     //supprimer l'exemplaire
                     this.proxyRetry.deleteExemplaire(demandeSupp, ligneFichierDtoSupp);
                     ligneFichierDtoSupp.setRetourSudoc(Constant.EXEMPLAIRE_SUPPRIME);

--- a/batch/src/test/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessorTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessorTest.java
@@ -1,0 +1,67 @@
+package fr.abes.item.batch.traitement.traiterlignesfichierchunk;
+
+import fr.abes.item.batch.traitement.ProxyRetry;
+import fr.abes.item.batch.traitement.model.LigneFichierDto;
+import fr.abes.item.batch.traitement.model.LigneFichierDtoSupp;
+import fr.abes.item.core.configuration.factory.StrategyFactory;
+import fr.abes.item.core.constant.Constant;
+import fr.abes.item.core.constant.TYPE_DEMANDE;
+import fr.abes.item.core.constant.TYPE_SUPPRESSION;
+import fr.abes.item.core.dto.ExemplaireWithTypeDto;
+import fr.abes.item.core.entities.item.DemandeSupp;
+import fr.abes.item.core.entities.item.EtatDemande;
+import fr.abes.item.core.service.IDemandeService;
+import fr.abes.item.core.service.ILigneFichierService;
+import fr.abes.item.core.service.ReferenceService;
+import fr.abes.item.core.service.impl.LigneFichierSuppService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LignesFichierProcessorTest {
+    @Mock
+    private StrategyFactory strategyFactory;
+    @Mock
+    private ProxyRetry proxyRetry;
+    @Mock
+    private ReferenceService referenceService;
+    @Mock
+    private IDemandeService demandeService;
+    @Mock
+    private LigneFichierSuppService ligneFichierSuppService;
+
+    @Test
+    void processSuppReturnsExplicitMessageWhenEpnIsNotFoundInNotice() throws Exception {
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService);
+        DemandeSupp demandeSupp = new DemandeSupp(123);
+        demandeSupp.setTypeSuppression(TYPE_SUPPRESSION.EPN);
+        demandeSupp.setEtatDemande(new EtatDemande(Constant.ETATDEM_ENCOURS));
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setPpn("123456789");
+        ligne.setEpn("987654321");
+
+        ReflectionTestUtils.setField(processor, "demandeService", demandeService);
+        ReflectionTestUtils.setField(processor, "demandeId", 123);
+
+        when(demandeService.findById(123)).thenReturn(demandeSupp);
+        when(strategyFactory.getStrategy(eq(ILigneFichierService.class), eq(TYPE_DEMANDE.SUPP)))
+                .thenReturn(ligneFichierSuppService);
+        when(ligneFichierSuppService.getExemplairesAndTypeDoc("123456789"))
+                .thenReturn(new ExemplaireWithTypeDto());
+
+        LigneFichierDto result = processor.process(ligne);
+
+        assertEquals(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE, result.getRetourSudoc());
+        verify(proxyRetry, never()).deleteExemplaire(demandeSupp, ligne);
+    }
+}


### PR DESCRIPTION
## Résumé
- empêche la suppression par EPN quand le PPN existe mais que l'EPN n'est pas présent dans la notice CBS
- retourne le message explicite `EPN inexistant ou erroné : traitement impossible` dans le fichier résultat
- ajoute un test de régression ciblé sur le processor batch

## Cause
Le processor écrivait déjà le message explicite si la notice n'était pas trouvée, mais continuait encore jusqu'à `deleteExemplaire(...)` quand la notice existait sans contenir l'EPN demandé.

## Validation
- `mvn -pl batch -am -Dtest=LignesFichierProcessorTest -DfailIfNoTests=false test`