### PR TITLE
SOA-692: centraliser le mapping des retours Sudoc batch

### DIFF
--- a/batch/src/main/java/fr/abes/item/batch/JobConfiguration.java
+++ b/batch/src/main/java/fr/abes/item/batch/JobConfiguration.java
@@ -5,6 +5,7 @@ import fr.abes.item.batch.traitement.model.LigneFichierDto;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoExemp;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoModif;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoRecouv;
+import fr.abes.item.batch.traitement.retoursudoc.BatchRetourSudocMapper;
 import fr.abes.item.batch.traitement.traiterlignesfichierchunk.LignesFichierProcessor;
 import fr.abes.item.batch.traitement.traiterlignesfichierchunk.LignesFichierReader;
 import fr.abes.item.batch.traitement.traiterlignesfichierchunk.LignesFichierWriter;
@@ -58,6 +59,7 @@ public class JobConfiguration {
     private final StrategyFactory strategyFactory;
     private final ProxyRetry proxyRetry;
     private final ReferenceService referenceService;
+    private final BatchRetourSudocMapper batchRetourSudocMapper;
     private final JdbcTemplate jdbcTemplate;
     private final ApplicationArguments applicationArguments;
 
@@ -79,10 +81,11 @@ public class JobConfiguration {
     private Integer nbPpnInFileResult;
 
 
-    public JobConfiguration(StrategyFactory strategyFactory, ProxyRetry proxyRetry, ReferenceService referenceService, @Qualifier("itemJdbcTemplate") JdbcTemplate jdbcTemplate, ApplicationArguments applicationArguments) {
+    public JobConfiguration(StrategyFactory strategyFactory, ProxyRetry proxyRetry, ReferenceService referenceService, BatchRetourSudocMapper batchRetourSudocMapper, @Qualifier("itemJdbcTemplate") JdbcTemplate jdbcTemplate, ApplicationArguments applicationArguments) {
         this.strategyFactory = strategyFactory;
         this.proxyRetry = proxyRetry;
         this.referenceService = referenceService;
+        this.batchRetourSudocMapper = batchRetourSudocMapper;
         this.jdbcTemplate = jdbcTemplate;
         this.applicationArguments = applicationArguments;
     }
@@ -101,7 +104,7 @@ public class JobConfiguration {
     @Bean
     @StepScope
     public LignesFichierProcessor processor() {
-        return new LignesFichierProcessor(strategyFactory, proxyRetry, this.referenceService);
+        return new LignesFichierProcessor(strategyFactory, proxyRetry, this.referenceService, batchRetourSudocMapper);
     }
 
     @Bean

--- a/batch/src/main/java/fr/abes/item/batch/traitement/ProxyRetry.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/ProxyRetry.java
@@ -98,10 +98,11 @@ public class ProxyRetry {
      * @throws CBSException : erreur CBS
      * @throws ZoneException : erreur de construction de la notice
      * @throws IOException : erreur de communication avec le CBS
+     * @throws QueryToSudocException : erreur sur la requête Sudoc
      */
     @Retryable(maxAttempts = 4, retryFor = IOException.class,
-            noRetryFor = {CBSException.class, ZoneException.class}, backoff = @Backoff(delay = 1000, multiplier = 2) )
-    public void newExemplaire(DemandeExemp demande, LigneFichierDtoExemp ligneFichierDtoExemp) throws CBSException, ZoneException, IOException {
+            noRetryFor = {CBSException.class, ZoneException.class, QueryToSudocException.class}, backoff = @Backoff(delay = 1000, multiplier = 2) )
+    public void newExemplaire(DemandeExemp demande, LigneFichierDtoExemp ligneFichierDtoExemp) throws CBSException, ZoneException, IOException, QueryToSudocException {
         try {
             ligneFichierDtoExemp.setRequete(ligneFichierExempService.getQueryToSudoc(demande.getIndexRecherche().getCode(), demande.getTypeExemp().getNumTypeExemp(), ligneFichierDtoExemp.getIndexRecherche().split(";")));
             //lancement de la requête de récupération de la notice dans le CBS
@@ -133,7 +134,7 @@ public class ProxyRetry {
         } catch (QueryToSudocException e) {
             ligneFichierDtoExemp.setNbReponses(ligneFichierExempService.getNbReponses());
             ligneFichierDtoExemp.setListePpn(traitementService.getCbs().getListePpn().toString().replace(';', ','));
-            ligneFichierDtoExemp.setRetourSudoc("");
+            throw e;
         } catch (DataAccessException d) {
             if (d.getRootCause() instanceof SQLException sqlEx) {
                 log.error("Erreur SQL : {}", sqlEx.getErrorCode());

--- a/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
@@ -19,8 +19,8 @@ public class BatchRetourSudocMapper {
         return exception.getMessage();
     }
 
-    public String mapMissingSuppressionEpn(DemandeSupp demandeSupp, LigneFichierDtoSupp ligneFichierDtoSupp) {
-        if (demandeSupp.getTypeSuppression() == TYPE_SUPPRESSION.EPN && ligneFichierDtoSupp.getEpn() != null) {
+    String mapMissingSuppressionEpn(DemandeSupp demandeSupp, LigneFichierDtoSupp ligneFichierDtoSupp) {
+        if (hasExplicitSuppressionEpnMappingContext(demandeSupp, ligneFichierDtoSupp)) {
             return Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE;
         }
         return Constant.WARN_NOTICE_EPN_INEXISTANT;
@@ -32,12 +32,19 @@ public class BatchRetourSudocMapper {
             LigneFichierDto ligneFichierDto
     ) {
         if (demande instanceof DemandeSupp demandeSupp
-                && demandeSupp.getTypeSuppression() == TYPE_SUPPRESSION.EPN
                 && ligneFichierDto instanceof LigneFichierDtoSupp ligneFichierDtoSupp
-                && ligneFichierDtoSupp.getEpn() != null
+                && hasExplicitSuppressionEpnMappingContext(demandeSupp, ligneFichierDtoSupp)
                 && Constant.ERR_FILE_NOTICE_NOT_FOUND.equals(exception.getMessage())) {
             return Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE;
         }
         return exception.getMessage();
+    }
+
+    private boolean hasExplicitSuppressionEpnMappingContext(
+            DemandeSupp demandeSupp,
+            LigneFichierDtoSupp ligneFichierDtoSupp
+    ) {
+        return demandeSupp.getTypeSuppression() == TYPE_SUPPRESSION.EPN
+                && ligneFichierDtoSupp.getEpn() != null;
     }
 }

--- a/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
@@ -19,7 +19,7 @@ public class BatchRetourSudocMapper {
         return exception.getMessage();
     }
 
-    String mapMissingSuppressionEpn(DemandeSupp demandeSupp, LigneFichierDtoSupp ligneFichierDtoSupp) {
+    public String mapMissingSuppressionEpn(DemandeSupp demandeSupp, LigneFichierDtoSupp ligneFichierDtoSupp) {
         if (hasExplicitSuppressionEpnMappingContext(demandeSupp, ligneFichierDtoSupp)) {
             return Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE;
         }

--- a/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
@@ -1,0 +1,43 @@
+package fr.abes.item.batch.traitement.retoursudoc;
+
+import fr.abes.item.batch.traitement.model.LigneFichierDto;
+import fr.abes.item.batch.traitement.model.LigneFichierDtoSupp;
+import fr.abes.item.core.constant.Constant;
+import fr.abes.item.core.constant.TYPE_SUPPRESSION;
+import fr.abes.item.core.entities.item.Demande;
+import fr.abes.item.core.entities.item.DemandeSupp;
+import fr.abes.item.core.exception.QueryToSudocException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BatchRetourSudocMapper {
+
+    public String map(Exception exception, Demande demande, LigneFichierDto ligneFichierDto) {
+        if (exception instanceof QueryToSudocException queryToSudocException) {
+            return mapQueryToSudocException(queryToSudocException, demande, ligneFichierDto);
+        }
+        return exception.getMessage();
+    }
+
+    public String mapMissingSuppressionEpn(DemandeSupp demandeSupp, LigneFichierDtoSupp ligneFichierDtoSupp) {
+        if (demandeSupp.getTypeSuppression() == TYPE_SUPPRESSION.EPN && ligneFichierDtoSupp.getEpn() != null) {
+            return Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE;
+        }
+        return Constant.WARN_NOTICE_EPN_INEXISTANT;
+    }
+
+    private String mapQueryToSudocException(
+            QueryToSudocException exception,
+            Demande demande,
+            LigneFichierDto ligneFichierDto
+    ) {
+        if (demande instanceof DemandeSupp demandeSupp
+                && demandeSupp.getTypeSuppression() == TYPE_SUPPRESSION.EPN
+                && ligneFichierDto instanceof LigneFichierDtoSupp ligneFichierDtoSupp
+                && ligneFichierDtoSupp.getEpn() != null
+                && Constant.ERR_FILE_NOTICE_NOT_FOUND.equals(exception.getMessage())) {
+            return Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE;
+        }
+        return exception.getMessage();
+    }
+}

--- a/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapper.java
@@ -3,6 +3,7 @@ package fr.abes.item.batch.traitement.retoursudoc;
 import fr.abes.item.batch.traitement.model.LigneFichierDto;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoSupp;
 import fr.abes.item.core.constant.Constant;
+import fr.abes.item.core.constant.TYPE_DEMANDE;
 import fr.abes.item.core.constant.TYPE_SUPPRESSION;
 import fr.abes.item.core.entities.item.Demande;
 import fr.abes.item.core.entities.item.DemandeSupp;
@@ -31,6 +32,10 @@ public class BatchRetourSudocMapper {
             Demande demande,
             LigneFichierDto ligneFichierDto
     ) {
+        if (demande.getTypeDemande() == TYPE_DEMANDE.RECOUV
+                && Constant.ERR_FILE_SEARCH_INDEX_CODE_NOT_COMPLIANT.equals(exception.getMessage())) {
+            return Constant.ERR_FILE_SEARCH_INDEX_NOT_COMPLIANT;
+        }
         if (demande instanceof DemandeSupp demandeSupp
                 && ligneFichierDto instanceof LigneFichierDtoSupp ligneFichierDtoSupp
                 && hasExplicitSuppressionEpnMappingContext(demandeSupp, ligneFichierDtoSupp)

--- a/batch/src/main/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessor.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessor.java
@@ -7,6 +7,7 @@ import fr.abes.cbs.notices.Exemplaire;
 import fr.abes.cbs.notices.Zone;
 import fr.abes.item.batch.traitement.ProxyRetry;
 import fr.abes.item.batch.traitement.model.*;
+import fr.abes.item.batch.traitement.retoursudoc.BatchRetourSudocMapper;
 import fr.abes.item.core.components.FichierSauvegardeSuppCsv;
 import fr.abes.item.core.components.FichierSauvegardeSuppTxt;
 import fr.abes.item.core.configuration.factory.StrategyFactory;
@@ -45,6 +46,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
     private final StrategyFactory strategyFactory;
     private final ProxyRetry proxyRetry;
     private final ReferenceService referenceService;
+    private final BatchRetourSudocMapper batchRetourSudocMapper;
     private FichierSauvegardeSuppTxt fichierSauvegardeSuppTxt;
     private FichierSauvegardeSuppCsv fichierSauvegardeSuppcsv;
 
@@ -52,10 +54,16 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
     private Integer demandeId;
     private IDemandeService demandeService;
 
-    public LignesFichierProcessor(StrategyFactory strategyFactory, ProxyRetry proxyRetry, ReferenceService referenceService) {
+    public LignesFichierProcessor(
+            StrategyFactory strategyFactory,
+            ProxyRetry proxyRetry,
+            ReferenceService referenceService,
+            BatchRetourSudocMapper batchRetourSudocMapper
+    ) {
         this.strategyFactory = strategyFactory;
         this.proxyRetry = proxyRetry;
         this.referenceService = referenceService;
+        this.batchRetourSudocMapper = batchRetourSudocMapper;
     }
 
 
@@ -97,7 +105,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
             };
         } catch (CBSException | ZoneException | QueryToSudocException | IOException e) {
             log.error(Constant.ERROR_FROM_SUDOC_REQUEST_OR_METHOD_SAVEXEMPLAIRE + e);
-            ligneFichierDto.setRetourSudoc(e.getMessage());
+            ligneFichierDto.setRetourSudoc(batchRetourSudocMapper.map(e, this.demande, ligneFichierDto));
         } catch (JDBCConnectionException | ConstraintViolationException j) {
             log.error("Erreur hibernate JDBC");
             log.error(j.toString());
@@ -110,7 +118,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
             log.error(ex.getMessage());
         } catch (Exception e) {
             log.error(Constant.ERROR_FROM_RECUP_NOTICETRAITEE + e);
-            ligneFichierDto.setRetourSudoc(e.getMessage());
+            ligneFichierDto.setRetourSudoc(batchRetourSudocMapper.map(e, this.demande, ligneFichierDto));
         }
         return ligneFichierDto;
     }
@@ -142,7 +150,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
      * @throws ZoneException : erreur de construction de la notice
      * @throws IOException   : erreur de communication avec le CBS
      */
-    private LigneFichierDtoExemp processDemandeExemp(LigneFichierDto ligneFichierDto) throws CBSException, ZoneException, IOException {
+    private LigneFichierDtoExemp processDemandeExemp(LigneFichierDto ligneFichierDto) throws CBSException, ZoneException, IOException, QueryToSudocException {
         DemandeExemp demandeExemp = (DemandeExemp) this.demande;
         LigneFichierDtoExemp ligneFichierDtoExemp = (LigneFichierDtoExemp) ligneFichierDto;
         this.proxyRetry.newExemplaire(demandeExemp, ligneFichierDtoExemp);
@@ -165,22 +173,11 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
         if(demandeSupp.getEtatDemande().getId() != Constant.ETATDEM_INTERROMPUE) {
                 //récupération des exemplaires existants pour cette ligne
                 LigneFichierSuppService service = ((LigneFichierSuppService) strategyFactory.getStrategy(ILigneFichierService.class, TYPE_DEMANDE.SUPP));
-                ExemplaireWithTypeDto exemplaireWithType;
-                try {
-                    exemplaireWithType = service.getExemplairesAndTypeDoc(ligneFichierDtoSupp.getPpn());
-                } catch (QueryToSudocException ex) {
-                    // EPN suppression case: write explicit message in result file.
-                    if (demandeSupp.getTypeSuppression() == TYPE_SUPPRESSION.EPN
-                            && Constant.ERR_FILE_NOTICE_NOT_FOUND.equals(ex.getMessage())) {
-                        ligneFichierDtoSupp.setRetourSudoc(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE);
-                        return ligneFichierDtoSupp;
-                    }
-                    throw ex;
-                }
+                ExemplaireWithTypeDto exemplaireWithType = service.getExemplairesAndTypeDoc(ligneFichierDtoSupp.getPpn());
                 if (ligneFichierDtoSupp.getEpn() != null) {
                     Optional<Exemplaire> exemplaireASupprimerOpt = exemplaireWithType.getExemplaires().stream().filter(exemplaire -> exemplaire.findZone("A99", 0).getValeur().equals(ligneFichierDtoSupp.getEpn())).findFirst();
                     if (exemplaireASupprimerOpt.isEmpty()) {
-                        ligneFichierDtoSupp.setRetourSudoc(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE);
+                        ligneFichierDtoSupp.setRetourSudoc(batchRetourSudocMapper.mapMissingSuppressionEpn(demandeSupp, ligneFichierDtoSupp));
                         return ligneFichierDtoSupp;
                     }
                     //Type de document non présent dans le fichier de sauvegarde txt, seulement dans le csv

--- a/batch/src/main/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessor.java
+++ b/batch/src/main/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessor.java
@@ -104,7 +104,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
                 default -> processDemandeRecouv(ligneFichierDto);
             };
         } catch (CBSException | ZoneException | QueryToSudocException | IOException e) {
-            log.error(Constant.ERROR_FROM_SUDOC_REQUEST_OR_METHOD_SAVEXEMPLAIRE + e);
+            log.error(Constant.ERROR_FROM_SUDOC_REQUEST_OR_METHOD_SAVEXEMPLAIRE, e);
             ligneFichierDto.setRetourSudoc(batchRetourSudocMapper.map(e, this.demande, ligneFichierDto));
         } catch (JDBCConnectionException | ConstraintViolationException j) {
             log.error("Erreur hibernate JDBC");
@@ -117,7 +117,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
         } catch (StorageException ex) {
             log.error(ex.getMessage());
         } catch (Exception e) {
-            log.error(Constant.ERROR_FROM_RECUP_NOTICETRAITEE + e);
+            log.error(Constant.ERROR_FROM_RECUP_NOTICETRAITEE, e);
             ligneFichierDto.setRetourSudoc(batchRetourSudocMapper.map(e, this.demande, ligneFichierDto));
         }
         return ligneFichierDto;
@@ -188,7 +188,7 @@ public class LignesFichierProcessor implements ItemProcessor<LigneFichierDto, Li
                     ligneFichierDtoSupp.setRetourSudoc(Constant.EXEMPLAIRE_SUPPRIME);
                 } else {
                     //si pas d'epn dans la ligne du fichier, on ne fait pas le traitement et on écrit directement le message dans le retour sudoc pour le fichier résultat
-                    ligneFichierDtoSupp.setRetourSudoc("Exemplaire inexistant");
+                    ligneFichierDtoSupp.setRetourSudoc(batchRetourSudocMapper.mapMissingSuppressionEpn(demandeSupp, ligneFichierDtoSupp));
                 }
         }
         return ligneFichierDtoSupp;

--- a/batch/src/test/java/fr/abes/item/batch/traitement/ProxyRetryTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/ProxyRetryTest.java
@@ -1,0 +1,96 @@
+package fr.abes.item.batch.traitement;
+
+import fr.abes.cbs.process.ProcessCBS;
+import fr.abes.item.batch.traitement.model.LigneFichierDtoExemp;
+import fr.abes.item.core.configuration.factory.StrategyFactory;
+import fr.abes.item.core.entities.item.DemandeExemp;
+import fr.abes.item.core.entities.item.IndexRecherche;
+import fr.abes.item.core.entities.item.TypeExemp;
+import fr.abes.item.core.exception.QueryToSudocException;
+import fr.abes.item.core.service.TraitementService;
+import fr.abes.item.core.service.impl.LigneFichierExempService;
+import fr.abes.item.core.service.impl.LigneFichierModifService;
+import fr.abes.item.core.service.impl.LigneFichierRecouvService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.retry.annotation.Retryable;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProxyRetryTest {
+    @Mock
+    private TraitementService traitementService;
+    @Mock
+    private StrategyFactory strategyFactory;
+    @Mock
+    private LigneFichierModifService ligneFichierModifService;
+    @Mock
+    private LigneFichierExempService ligneFichierExempService;
+    @Mock
+    private LigneFichierRecouvService ligneFichierRecouvService;
+    @Mock
+    private ProcessCBS cbs;
+
+    @Test
+    void newExemplaireRethrowsQueryToSudocExceptionAfterFillingBatchMetadata() throws Exception {
+        ProxyRetry proxyRetry = new ProxyRetry(
+                traitementService,
+                strategyFactory,
+                ligneFichierModifService,
+                ligneFichierExempService,
+                ligneFichierRecouvService
+        );
+        DemandeExemp demande = new DemandeExemp(123);
+        demande.setIndexRecherche(new IndexRecherche(1, "PPN", "PPN", 1));
+        demande.setTypeExemp(new TypeExemp(2));
+
+        LigneFichierDtoExemp ligne = new LigneFichierDtoExemp();
+        ligne.setIndexRecherche("123456789");
+
+        QueryToSudocException expected = new QueryToSudocException("notice introuvable");
+
+        when(ligneFichierExempService.getQueryToSudoc(eq("PPN"), eq(2), any(String[].class)))
+                .thenReturn("che PPN 123456789");
+        when(ligneFichierExempService.launchQueryToSudoc(demande, "123456789"))
+                .thenThrow(expected);
+        when(ligneFichierExempService.getNbReponses()).thenReturn(2);
+        when(traitementService.getCbs()).thenReturn(cbs);
+        when(cbs.getListePpn()).thenReturn(new StringBuilder("230721486;23309668X;"));
+
+        QueryToSudocException thrown = assertThrows(
+                QueryToSudocException.class,
+                () -> proxyRetry.newExemplaire(demande, ligne)
+        );
+
+        assertSame(expected, thrown);
+        assertEquals(2, ligne.getNbReponses());
+        assertEquals("230721486,23309668X,", ligne.getListePpn());
+        assertNull(ligne.getRetourSudoc());
+    }
+
+    @Test
+    void newExemplaireDoesNotRetryQueryToSudocException() throws NoSuchMethodException {
+        Method method = ProxyRetry.class.getMethod(
+                "newExemplaire",
+                DemandeExemp.class,
+                LigneFichierDtoExemp.class
+        );
+
+        Retryable retryable = method.getAnnotation(Retryable.class);
+
+        assertTrue(Arrays.asList(retryable.noRetryFor()).contains(QueryToSudocException.class));
+    }
+}

--- a/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
@@ -1,0 +1,74 @@
+package fr.abes.item.batch.traitement.retoursudoc;
+
+import fr.abes.item.batch.traitement.model.LigneFichierDtoExemp;
+import fr.abes.item.batch.traitement.model.LigneFichierDtoSupp;
+import fr.abes.item.core.constant.Constant;
+import fr.abes.item.core.constant.TYPE_SUPPRESSION;
+import fr.abes.item.core.entities.item.DemandeExemp;
+import fr.abes.item.core.entities.item.DemandeSupp;
+import fr.abes.item.core.exception.QueryToSudocException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BatchRetourSudocMapperTest {
+
+    private final BatchRetourSudocMapper mapper = new BatchRetourSudocMapper();
+
+    @Test
+    void mapsSuppressionEpnNoticeNotFoundToExplicitBusinessMessage() {
+        DemandeSupp demande = new DemandeSupp(1);
+        demande.setTypeSuppression(TYPE_SUPPRESSION.EPN);
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setEpn("987654321");
+
+        String result = mapper.map(
+                new QueryToSudocException(Constant.ERR_FILE_NOTICE_NOT_FOUND),
+                demande,
+                ligne
+        );
+
+        assertEquals(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE, result);
+    }
+
+    @Test
+    void keepsRawMessageForUnknownQueryToSudocCases() {
+        DemandeExemp demande = new DemandeExemp(1);
+        LigneFichierDtoExemp ligne = new LigneFichierDtoExemp();
+
+        String result = mapper.map(
+                new QueryToSudocException(Constant.ERR_FILE_MULTIPLES_NOTICES_FOUND + "230721486,23309668X"),
+                demande,
+                ligne
+        );
+
+        assertEquals(Constant.ERR_FILE_MULTIPLES_NOTICES_FOUND + "230721486,23309668X", result);
+    }
+
+    @Test
+    void keepsRawMessageForGenericIOExceptionFallback() {
+        DemandeExemp demande = new DemandeExemp(1);
+        LigneFichierDtoExemp ligne = new LigneFichierDtoExemp();
+
+        String result = mapper.map(new IOException("socket timeout"), demande, ligne);
+
+        assertEquals("socket timeout", result);
+    }
+
+    @Test
+    void mapsSuppressionEpnMissingInNoticeWithoutException() {
+        DemandeSupp demande = new DemandeSupp(1);
+        demande.setTypeSuppression(TYPE_SUPPRESSION.EPN);
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setEpn("987654321");
+
+        assertEquals(
+                Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE,
+                mapper.mapMissingSuppressionEpn(demande, ligne)
+        );
+    }
+}

--- a/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
@@ -10,8 +10,11 @@ import fr.abes.item.core.exception.QueryToSudocException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class BatchRetourSudocMapperTest {
 
@@ -68,6 +71,64 @@ class BatchRetourSudocMapperTest {
 
         assertEquals(
                 Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE,
+                mapper.mapMissingSuppressionEpn(demande, ligne)
+        );
+    }
+
+    @Test
+    void keepsCaseSpecificMissingSuppressionMappingNonPublic() throws NoSuchMethodException {
+        Method method = BatchRetourSudocMapper.class.getDeclaredMethod(
+                "mapMissingSuppressionEpn",
+                DemandeSupp.class,
+                LigneFichierDtoSupp.class
+        );
+
+        assertFalse(Modifier.isPublic(method.getModifiers()));
+    }
+
+    @Test
+    void doesNotMapSuppressionPpnNoticeNotFoundToExplicitEpnMessage() {
+        DemandeSupp demande = new DemandeSupp(1);
+        demande.setTypeSuppression(TYPE_SUPPRESSION.PPN);
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setEpn("987654321");
+
+        String result = mapper.map(
+                new QueryToSudocException(Constant.ERR_FILE_NOTICE_NOT_FOUND),
+                demande,
+                ligne
+        );
+
+        assertEquals(Constant.ERR_FILE_NOTICE_NOT_FOUND, result);
+    }
+
+    @Test
+    void doesNotMapSuppressionWithoutEpnToExplicitEpnMessage() {
+        DemandeSupp demande = new DemandeSupp(1);
+        demande.setTypeSuppression(TYPE_SUPPRESSION.EPN);
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+
+        String result = mapper.map(
+                new QueryToSudocException(Constant.ERR_FILE_NOTICE_NOT_FOUND),
+                demande,
+                ligne
+        );
+
+        assertEquals(Constant.ERR_FILE_NOTICE_NOT_FOUND, result);
+    }
+
+    @Test
+    void keepsGenericWarningForMissingSuppressionFallbackCase() {
+        DemandeSupp demande = new DemandeSupp(1);
+        demande.setTypeSuppression(TYPE_SUPPRESSION.PPN);
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setEpn("987654321");
+
+        assertEquals(
+                Constant.WARN_NOTICE_EPN_INEXISTANT,
                 mapper.mapMissingSuppressionEpn(demande, ligne)
         );
     }

--- a/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
@@ -10,11 +10,8 @@ import fr.abes.item.core.exception.QueryToSudocException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class BatchRetourSudocMapperTest {
 
@@ -73,17 +70,6 @@ class BatchRetourSudocMapperTest {
                 Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE,
                 mapper.mapMissingSuppressionEpn(demande, ligne)
         );
-    }
-
-    @Test
-    void keepsCaseSpecificMissingSuppressionMappingNonPublic() throws NoSuchMethodException {
-        Method method = BatchRetourSudocMapper.class.getDeclaredMethod(
-                "mapMissingSuppressionEpn",
-                DemandeSupp.class,
-                LigneFichierDtoSupp.class
-        );
-
-        assertFalse(Modifier.isPublic(method.getModifiers()));
     }
 
     @Test

--- a/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/retoursudoc/BatchRetourSudocMapperTest.java
@@ -1,10 +1,12 @@
 package fr.abes.item.batch.traitement.retoursudoc;
 
 import fr.abes.item.batch.traitement.model.LigneFichierDtoExemp;
+import fr.abes.item.batch.traitement.model.LigneFichierDtoRecouv;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoSupp;
 import fr.abes.item.core.constant.Constant;
 import fr.abes.item.core.constant.TYPE_SUPPRESSION;
 import fr.abes.item.core.entities.item.DemandeExemp;
+import fr.abes.item.core.entities.item.DemandeRecouv;
 import fr.abes.item.core.entities.item.DemandeSupp;
 import fr.abes.item.core.exception.QueryToSudocException;
 import org.junit.jupiter.api.Test;
@@ -117,5 +119,19 @@ class BatchRetourSudocMapperTest {
                 Constant.WARN_NOTICE_EPN_INEXISTANT,
                 mapper.mapMissingSuppressionEpn(demande, ligne)
         );
+    }
+
+    @Test
+    void mapsRecouvInvalidSearchIndexToBusinessMessage() {
+        DemandeRecouv demande = new DemandeRecouv(1);
+        LigneFichierDtoRecouv ligne = new LigneFichierDtoRecouv();
+
+        String result = mapper.map(
+                new QueryToSudocException(Constant.ERR_FILE_SEARCH_INDEX_CODE_NOT_COMPLIANT),
+                demande,
+                ligne
+        );
+
+        assertEquals(Constant.ERR_FILE_SEARCH_INDEX_NOT_COMPLIANT, result);
     }
 }

--- a/batch/src/test/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessorTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessorTest.java
@@ -2,14 +2,18 @@ package fr.abes.item.batch.traitement.traiterlignesfichierchunk;
 
 import fr.abes.item.batch.traitement.ProxyRetry;
 import fr.abes.item.batch.traitement.model.LigneFichierDto;
+import fr.abes.item.batch.traitement.model.LigneFichierDtoExemp;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoSupp;
+import fr.abes.item.batch.traitement.retoursudoc.BatchRetourSudocMapper;
 import fr.abes.item.core.configuration.factory.StrategyFactory;
 import fr.abes.item.core.constant.Constant;
 import fr.abes.item.core.constant.TYPE_DEMANDE;
 import fr.abes.item.core.constant.TYPE_SUPPRESSION;
 import fr.abes.item.core.dto.ExemplaireWithTypeDto;
+import fr.abes.item.core.entities.item.DemandeExemp;
 import fr.abes.item.core.entities.item.DemandeSupp;
 import fr.abes.item.core.entities.item.EtatDemande;
+import fr.abes.item.core.exception.QueryToSudocException;
 import fr.abes.item.core.service.IDemandeService;
 import fr.abes.item.core.service.ILigneFichierService;
 import fr.abes.item.core.service.ReferenceService;
@@ -28,6 +32,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LignesFichierProcessorTest {
+    private final BatchRetourSudocMapper batchRetourSudocMapper = new BatchRetourSudocMapper();
+
     @Mock
     private StrategyFactory strategyFactory;
     @Mock
@@ -41,7 +47,7 @@ class LignesFichierProcessorTest {
 
     @Test
     void processSuppReturnsExplicitMessageWhenEpnIsNotFoundInNotice() throws Exception {
-        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService);
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService, batchRetourSudocMapper);
         DemandeSupp demandeSupp = new DemandeSupp(123);
         demandeSupp.setTypeSuppression(TYPE_SUPPRESSION.EPN);
         demandeSupp.setEtatDemande(new EtatDemande(Constant.ETATDEM_ENCOURS));
@@ -52,6 +58,7 @@ class LignesFichierProcessorTest {
 
         ReflectionTestUtils.setField(processor, "demandeService", demandeService);
         ReflectionTestUtils.setField(processor, "demandeId", 123);
+        ReflectionTestUtils.setField(processor, "demande", demandeSupp);
 
         when(demandeService.findById(123)).thenReturn(demandeSupp);
         when(strategyFactory.getStrategy(eq(ILigneFichierService.class), eq(TYPE_DEMANDE.SUPP)))
@@ -63,5 +70,48 @@ class LignesFichierProcessorTest {
 
         assertEquals(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE, result.getRetourSudoc());
         verify(proxyRetry, never()).deleteExemplaire(demandeSupp, ligne);
+    }
+
+    @Test
+    void processSuppUsesMapperWhenNoticeLookupThrowsQueryToSudocException() throws Exception {
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService, batchRetourSudocMapper);
+        DemandeSupp demandeSupp = new DemandeSupp(123);
+        demandeSupp.setTypeSuppression(TYPE_SUPPRESSION.EPN);
+        demandeSupp.setEtatDemande(new EtatDemande(Constant.ETATDEM_ENCOURS));
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setPpn("123456789");
+        ligne.setEpn("987654321");
+
+        ReflectionTestUtils.setField(processor, "demandeService", demandeService);
+        ReflectionTestUtils.setField(processor, "demandeId", 123);
+        ReflectionTestUtils.setField(processor, "demande", demandeSupp);
+
+        when(demandeService.findById(123)).thenReturn(demandeSupp);
+        when(strategyFactory.getStrategy(eq(ILigneFichierService.class), eq(TYPE_DEMANDE.SUPP)))
+                .thenReturn(ligneFichierSuppService);
+        when(ligneFichierSuppService.getExemplairesAndTypeDoc("123456789"))
+                .thenThrow(new QueryToSudocException(Constant.ERR_FILE_NOTICE_NOT_FOUND));
+
+        LigneFichierDto result = processor.process(ligne);
+
+        assertEquals(Constant.ERR_FILE_EPN_INEXISTANT_OR_ERRONE, result.getRetourSudoc());
+        verify(proxyRetry, never()).deleteExemplaire(demandeSupp, ligne);
+    }
+
+    @Test
+    void processExempFallsBackToMapperWhenProxyRetryThrowsQueryToSudocException() throws Exception {
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService, batchRetourSudocMapper);
+        DemandeExemp demandeExemp = new DemandeExemp(456);
+        LigneFichierDtoExemp ligne = new LigneFichierDtoExemp();
+
+        ReflectionTestUtils.setField(processor, "demande", demandeExemp);
+
+        org.mockito.Mockito.doThrow(new QueryToSudocException(Constant.ERR_FILE_NOTICE_NOT_FOUND))
+                .when(proxyRetry).newExemplaire(demandeExemp, ligne);
+
+        LigneFichierDto result = processor.process(ligne);
+
+        assertEquals(Constant.ERR_FILE_NOTICE_NOT_FOUND, result.getRetourSudoc());
     }
 }

--- a/batch/src/test/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessorTest.java
+++ b/batch/src/test/java/fr/abes/item/batch/traitement/traiterlignesfichierchunk/LignesFichierProcessorTest.java
@@ -1,5 +1,11 @@
 package fr.abes.item.batch.traitement.traiterlignesfichierchunk;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import fr.abes.item.batch.traitement.ProxyRetry;
 import fr.abes.item.batch.traitement.model.LigneFichierDto;
 import fr.abes.item.batch.traitement.model.LigneFichierDtoExemp;
@@ -24,7 +30,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -44,6 +53,8 @@ class LignesFichierProcessorTest {
     private IDemandeService demandeService;
     @Mock
     private LigneFichierSuppService ligneFichierSuppService;
+    @Mock
+    private BatchRetourSudocMapper mockedBatchRetourSudocMapper;
 
     @Test
     void processSuppReturnsExplicitMessageWhenEpnIsNotFoundInNotice() throws Exception {
@@ -113,5 +124,120 @@ class LignesFichierProcessorTest {
         LigneFichierDto result = processor.process(ligne);
 
         assertEquals(Constant.ERR_FILE_NOTICE_NOT_FOUND, result.getRetourSudoc());
+    }
+
+    @Test
+    void processSuppWithoutEpnUsesMapperWarningMessage() throws Exception {
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService, mockedBatchRetourSudocMapper);
+        DemandeSupp demandeSupp = new DemandeSupp(123);
+        demandeSupp.setTypeSuppression(TYPE_SUPPRESSION.EPN);
+        demandeSupp.setEtatDemande(new EtatDemande(Constant.ETATDEM_ENCOURS));
+
+        LigneFichierDtoSupp ligne = new LigneFichierDtoSupp();
+        ligne.setPpn("123456789");
+
+        ReflectionTestUtils.setField(processor, "demandeService", demandeService);
+        ReflectionTestUtils.setField(processor, "demandeId", 123);
+        ReflectionTestUtils.setField(processor, "demande", demandeSupp);
+
+        when(demandeService.findById(123)).thenReturn(demandeSupp);
+        when(strategyFactory.getStrategy(eq(ILigneFichierService.class), eq(TYPE_DEMANDE.SUPP)))
+                .thenReturn(ligneFichierSuppService);
+        when(ligneFichierSuppService.getExemplairesAndTypeDoc("123456789"))
+                .thenReturn(new ExemplaireWithTypeDto());
+        when(mockedBatchRetourSudocMapper.mapMissingSuppressionEpn(demandeSupp, ligne))
+                .thenReturn(Constant.WARN_NOTICE_EPN_INEXISTANT);
+
+        LigneFichierDto result = processor.process(ligne);
+
+        assertEquals(Constant.WARN_NOTICE_EPN_INEXISTANT, result.getRetourSudoc());
+        verify(mockedBatchRetourSudocMapper).mapMissingSuppressionEpn(demandeSupp, ligne);
+    }
+
+    @Test
+    void processExempLogsThrowableForSudocExceptionPath() throws Exception {
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService, batchRetourSudocMapper);
+        DemandeExemp demandeExemp = new DemandeExemp(456);
+        LigneFichierDtoExemp ligne = new LigneFichierDtoExemp();
+
+        ReflectionTestUtils.setField(processor, "demande", demandeExemp);
+
+        TestLogAppender appender = attachLogAppender();
+        try {
+            org.mockito.Mockito.doThrow(new QueryToSudocException(Constant.ERR_FILE_NOTICE_NOT_FOUND))
+                    .when(proxyRetry).newExemplaire(demandeExemp, ligne);
+
+            processor.process(ligne);
+
+            LogEvent event = getLastErrorEvent(appender.events);
+            assertEquals(Constant.ERROR_FROM_SUDOC_REQUEST_OR_METHOD_SAVEXEMPLAIRE, event.getMessage().getFormattedMessage());
+            assertNotNull(event.getThrown());
+        } finally {
+            detachLogAppender(appender);
+        }
+    }
+
+    @Test
+    void processExempLogsThrowableForGenericExceptionPath() throws Exception {
+        LignesFichierProcessor processor = new LignesFichierProcessor(strategyFactory, proxyRetry, referenceService, batchRetourSudocMapper);
+        DemandeExemp demandeExemp = new DemandeExemp(456);
+        LigneFichierDtoExemp ligne = new LigneFichierDtoExemp();
+
+        ReflectionTestUtils.setField(processor, "demande", demandeExemp);
+
+        TestLogAppender appender = attachLogAppender();
+        try {
+            org.mockito.Mockito.doThrow(new IllegalStateException("boom"))
+                    .when(proxyRetry).newExemplaire(demandeExemp, ligne);
+
+            processor.process(ligne);
+
+            LogEvent event = getLastErrorEvent(appender.events);
+            assertEquals(Constant.ERROR_FROM_RECUP_NOTICETRAITEE, event.getMessage().getFormattedMessage());
+            assertNotNull(event.getThrown());
+        } finally {
+            detachLogAppender(appender);
+        }
+    }
+
+    private TestLogAppender attachLogAppender() {
+        TestLogAppender appender = new TestLogAppender();
+        appender.start();
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        LoggerConfig loggerConfig = context.getConfiguration().getLoggerConfig(LignesFichierProcessor.class.getName());
+        loggerConfig.addAppender(appender, null, null);
+        context.updateLoggers();
+        return appender;
+    }
+
+    private void detachLogAppender(TestLogAppender appender) {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        LoggerConfig loggerConfig = context.getConfiguration().getLoggerConfig(LignesFichierProcessor.class.getName());
+        loggerConfig.removeAppender(appender.getName());
+        context.updateLoggers();
+        appender.stop();
+    }
+
+    private LogEvent getLastErrorEvent(List<LogEvent> events) {
+        for (int i = events.size() - 1; i >= 0; i--) {
+            LogEvent event = events.get(i);
+            if (event.getLevel().isMoreSpecificThan(org.apache.logging.log4j.Level.ERROR)) {
+                return event;
+            }
+        }
+        throw new AssertionError("No ERROR log event captured");
+    }
+
+    private static final class TestLogAppender extends AbstractAppender {
+        private final List<LogEvent> events = new java.util.ArrayList<>();
+
+        private TestLogAppender() {
+            super("test-log-appender", null, PatternLayout.createDefaultLayout(), false, null);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
     }
 }

--- a/docs/superpowers/specs/2026-06-22-batch-retour-sudoc-mapping-design.md
+++ b/docs/superpowers/specs/2026-06-22-batch-retour-sudoc-mapping-design.md
@@ -1,0 +1,139 @@
+# Refonte du mapping des retours batch Sudoc
+
+Date: 2026-06-22
+Depot: `item-api`
+Ticket de rattachement: `SOA-692`
+
+## Objectif
+
+Refondre le mapping des erreurs CBS/Sudoc dans `item-api` pour les seuls retours batch et fichiers resultat.
+
+Le besoin ne couvre pas:
+- les endpoints API
+- les ecrans de simulation
+- la bibliotheque `accescbs`
+
+## Constat actuel
+
+Le batch propage encore largement des messages techniques ou generiques directement issus des exceptions:
+- `e.getMessage()` est ecrit tel quel dans plusieurs cas
+- certains cas sont differencies localement dans `LignesFichierProcessor`
+- au moins un cas d'exemplarisation ecrit un message vide dans `retourSudoc`
+
+Cela rend le comportement difficile a maintenir et non homogene entre types de demandes.
+
+## Decision de conception
+
+Creer un composant dedie de mapping, cote `item-api`, pour centraliser la transformation:
+- entree: contexte batch + exception
+- sortie: message a ecrire dans `retourSudoc`
+
+Le mapping sera pilote prioritairement par:
+1. le type d'exception
+2. le contexte metier du batch
+
+Le texte du message source ne sera utilise qu'en second choix si le type d'exception ne suffit pas.
+
+## Perimetre fonctionnel
+
+Le composant couvre uniquement les retours ecrits dans les traitements batch et exposes dans les fichiers resultat.
+
+Les types de demandes concernes sont:
+- `SUPP`
+- `EXEMP`
+- `RECOUV`
+- `MODIF`
+
+Le point d'integration principal reste `LignesFichierProcessor`.
+
+## Regle generale
+
+- Cas metier connu: ecrire un message metier explicite
+- Cas non classe: conserver le message brut `e.getMessage()`
+
+Cette regle preserve l'observabilite fonctionnelle sans etendre artificiellement le scope.
+
+## Premiers cas a couvrir
+
+### Suppression par EPN
+
+Cas deja connus dans `SOA-689`, a conserver dans la solution centralisee:
+- notice introuvable lors d'une suppression par `EPN`
+- `EPN` absent de la notice
+
+Message cible:
+- `EPN inexistant ou erroné : traitement impossible`
+
+### Exemplarisation
+
+Cas a corriger:
+- `QueryToSudocException` aujourd'hui transformee en message vide
+
+Comportement cible:
+- ne plus jamais ecrire de chaine vide dans `retourSudoc`
+- utiliser le mapper central
+
+### Autres cas
+
+Les autres erreurs CBS/Sudoc non encore classees restent en fallback:
+- message brut `e.getMessage()`
+
+## Architecture cible
+
+Ajouter un composant dedie, par exemple:
+- `BatchRetourSudocMapper`
+
+Responsabilites:
+- recevoir l'exception et le contexte de traitement
+- reconnaitre les cas metier connus
+- retourner le message final pour `retourSudoc`
+
+Contexte minimal attendu:
+- type de demande
+- type de suppression si la demande est `SUPP`
+- ligne en cours si utile
+
+Le composant ne doit:
+- ni logger lui-meme la logique metier
+- ni faire d'acces CBS
+- ni modifier les DTO
+
+Il ne fait que decider du message.
+
+## Impacts de code prevus
+
+### Batch
+
+Refactorer `LignesFichierProcessor` pour:
+- deleguer le choix du message au mapper
+- reduire les `setRetourSudoc(...)` eparpilles
+- conserver les cas nominaux de succes inchanges
+
+### Exemplarisation
+
+Refactorer le traitement actuel qui transforme une `QueryToSudocException` en chaine vide pour passer par le mapper central.
+
+## Strategie de tests
+
+Ajouter des tests unitaires du mapper couvrant:
+- suppression `EPN` + notice introuvable
+- suppression `EPN` + exemplaire absent de la notice
+- fallback sur message brut pour cas non connus
+- exemplarisation avec `QueryToSudocException` non vide
+
+Conserver ou etendre les tests batch existants pour verifier l'ecriture finale dans `retourSudoc`.
+
+## Hors perimetre
+
+- modification des messages bas niveau dans `accescbs`
+- harmonisation des messages REST
+- refonte des erreurs de simulation
+- normalisation de tous les messages CBS existants en une seule iteration
+
+## Critere de succes
+
+Le correctif est considere termine si:
+- les cas metier connus sont centralises dans un mapper unique
+- aucun retour batch ne devient vide pour une erreur CBS/Sudoc
+- les cas non classes continuent a remonter `e.getMessage()`
+- les tests couvrent au minimum suppression `EPN` et exemplarisation


### PR DESCRIPTION
## Résumé

Cette PR traite SOA-692 sur le périmètre `item-api` batch, en centralisant le mapping des retours Sudoc vers le fichier résultat.

## Ce qui change

- ajout d'un `BatchRetourSudocMapper` dédié au mapping des messages batch
- utilisation systématique de ce mapper dans `LignesFichierProcessor`
- conservation du message brut `e.getMessage()` comme fallback lorsqu'aucun mapping métier n'est défini
- correction du cas `QueryToSudocException` en exemplarisation pour éviter un `retourSudoc` vide
- harmonisation du message RECOUV sur l'index de recherche non conforme
- ajout de tests unitaires et de non-régression sur les cas EXEMP / SUPP / RECOUV

## Pourquoi

L'inventaire SOA-692 montrait plusieurs retours CBS ou techniques remontés de manière trop générique dans les fichiers résultat batch, avec au moins un cas où le message utilisateur pouvait être vide.

## Cohérence avec SOA-689

Le comportement introduit par SOA-689 est conservé : les cas de suppression liés à un EPN absent de la notice continuent à remonter un message explicite `EPN inexistant ou erroné : traitement impossible` quand le contexte métier le justifie. La branche est basée sur `develop`, qui contient déjà SOA-689, et les tests ajoutés couvrent ce point.

## Impact

- pas de changement de contrat REST
- pas de changement côté `item-client`
- pas de changement côté `accescbs`
- amélioration de la lisibilité et de la cohérence des retours batch côté `item-api`

## Vérification

Commande exécutée :

```bash
mvn -pl batch -am "-Dtest=BatchRetourSudocMapperTest,ProxyRetryTest,LignesFichierProcessorTest" -DfailIfNoTests=false test
```

Résultat : `BUILD SUCCESS`, 16 tests exécutés, 0 échec, 0 erreur.
