### PR TITLE
SOA-478 Corriger et harmoniser les compteurs DAO EXEMP

### DIFF
--- a/core/src/main/java/fr/abes/item/core/repository/item/ILigneFichierExempDao.java
+++ b/core/src/main/java/fr/abes/item/core/repository/item/ILigneFichierExempDao.java
@@ -48,7 +48,7 @@ public interface ILigneFichierExempDao extends JpaRepository<LigneFichierExemp, 
      * @return Une liste contenant toutes les lignes d'exemplaires correspondant à une demande
      *          qui n'ont pas été traités (= absence d'echec sur le traitement de ces lignes)
      */
-    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.traitee=1 order by lf.position")
+    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.traitee=0")
     int getNbLigneFichierNonTraitee(@Param("numDemande") Integer numDemande);
 
     /**
@@ -82,13 +82,13 @@ public interface ILigneFichierExempDao extends JpaRepository<LigneFichierExemp, 
     @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.traitee = 1 and lf.nbReponse != 0")
     int getNbReponseTrouveesByDemande(@Param("numDemande") Integer numDemande);
 
-    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.nbReponse=1")
+    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.traitee = 1 and lf.nbReponse=1")
     int getNbUneReponseByDemande(@Param("numDemande") Integer numDemande);
 
-    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.nbReponse=0")
+    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.traitee = 1 and lf.nbReponse=0")
     int getNbZeroReponseByDemande(@Param("numDemande") Integer numDemande);
 
-    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.nbReponse>1")
+    @Query("select count(lf) from LigneFichierExemp lf where lf.demandeExemp.numDemande = :numDemande and lf.traitee = 1 and lf.nbReponse>1")
     int getNbReponseMultipleByDemande(@Param("numDemande") Integer numDemande);
 
     /**Supprime les lignes de fichier d'exemplaire associées à une demande

--- a/core/src/test/java/fr/abes/item/core/repository/item/ILigneFichierExempDaoQueryTest.java
+++ b/core/src/test/java/fr/abes/item/core/repository/item/ILigneFichierExempDaoQueryTest.java
@@ -1,0 +1,35 @@
+package fr.abes.item.core.repository.item;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.Query;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ILigneFichierExempDaoQueryTest {
+
+    @Test
+    void getNbLigneFichierNonTraiteeShouldFilterUntreatedLines() throws NoSuchMethodException {
+        assertThat(getNormalizedQueryValue("getNbLigneFichierNonTraitee"))
+                .contains("andlf.traitee=0");
+    }
+
+    @Test
+    void responseCountersShouldOnlyCountProcessedLines() throws NoSuchMethodException {
+        assertThat(getNormalizedQueryValue("getNbReponseTrouveesByDemande"))
+                .contains("andlf.traitee=1andlf.nbreponse!=0");
+        assertThat(getNormalizedQueryValue("getNbUneReponseByDemande"))
+                .contains("andlf.traitee=1andlf.nbreponse=1");
+        assertThat(getNormalizedQueryValue("getNbZeroReponseByDemande"))
+                .contains("andlf.traitee=1andlf.nbreponse=0");
+        assertThat(getNormalizedQueryValue("getNbReponseMultipleByDemande"))
+                .contains("andlf.traitee=1andlf.nbreponse>1");
+    }
+
+    private String getNormalizedQueryValue(String methodName) throws NoSuchMethodException {
+        Method method = ILigneFichierExempDao.class.getMethod(methodName, Integer.class);
+        Query query = method.getAnnotation(Query.class);
+        return query.value().replaceAll("\\s+", "").toLowerCase();
+    }
+}


### PR DESCRIPTION
## Résumé
- corrige le comptage des lignes non traitées dans le DAO EXEMP
- harmonise les compteurs de réponses EXEMP pour ne prendre en compte que les lignes déjà traitées
- ajoute un test de régression sur les annotations `@Query`

## Cause
Le DAO `ILigneFichierExempDao` comptait les lignes `traitee=1` dans `getNbLigneFichierNonTraitee`, et les compteurs `0 / 1 / multiples réponses` n'étaient pas alignés sur le filtrage `traitee = 1` utilisé sur les autres services.

## Validation
- `mvn -pl core -Dtest=ILigneFichierExempDaoQueryTest test`
- `mvn -pl core test`