### PR TITLE
feat(ci): add security scans (Trivy, Dependabot, SonarCloud)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ci"
+      - "security"

--- a/.github/workflows/build-test-pubtodockerhub.yml
+++ b/.github/workflows/build-test-pubtodockerhub.yml
@@ -23,10 +23,18 @@ jobs:
 
 
       - name: "Build: checkout source code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Build: build docker image"
         run: |
           docker build . -t localimage:latest
+      - name: "Security: Trivy scan (api-image)"
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: 'localimage:latest'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
       - name: "Push: prepare version from git tags/branchs"
         id: docker_tag_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,36 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.SONAR_TOKEN != '' }}
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Set up JDK 21"
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: maven
+
+      - name: "Build and analyze with SonarCloud"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          mvn -B verify
+          org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          -Dsonar.projectKey=abes-esr_item-api
+          -Dsonar.organization=abes-esr
+          -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
## Summary
- Add Trivy container vulnerability scan before DockerHub push (blocks on CRITICAL/HIGH CVEs)
- Add Dependabot config for Maven dependencies and GitHub Actions (weekly scans)
- Add SonarCloud SAST analysis workflow (skipped if SONAR_TOKEN not yet configured)
- Upgrade checkout action from v3 to v4

## Test plan
- [ ] Verify `build-test-pubtodockerhub` workflow passes with Trivy scan on develop
- [ ] Verify Dependabot creates PRs after merge (check Security tab)
- [ ] Verify SonarCloud workflow is skipped gracefully without SONAR_TOKEN
- [ ] After validation on dev/test, configure SONAR_TOKEN secret and SonarCloud project

## Residual risk
- Trivy may block the pipeline on first run if CRITICAL CVEs exist in base images — review and fix or add exceptions
- SonarCloud workflow is a no-op until SONAR_TOKEN is added to GitHub secrets